### PR TITLE
rust: fix nixpkgs warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,8 @@
             version = "unstable";
             srcs = [./rust ./testcases];
             sourceRoot = "rust";
-            cargoHash = "sha256-xD8gINh6B3yXae7SjatVBzLo3+KD2xToXQFheF5eyM8=";
+            useFetchCargoVendor = true;
+            cargoHash = "sha256-GT4AF9PKAntS5GD8TlSnNpxSmUBoVY6ri0t61XTGTas=";
 
             buildInputs = [
               openssl.dev


### PR DESCRIPTION
```
rustPlatform.fetchCargoTarball is deprecated in favor of rustPlatform.fetchCargoVendor.
If you are using buildRustPackage, try setting useFetchCargoVendor = true and regenerating cargoHash.
See the 25.05 release notes for more information.
```